### PR TITLE
Make example license messages use literal blocks

### DIFF
--- a/apache-v2.0.rst
+++ b/apache-v2.0.rst
@@ -190,6 +190,8 @@ recommend that a file or class name and description of purpose be included on
 the same "printed page" as the copyright notice for easier identification within
 third-party archives.
 
+::
+
     Copyright [yyyy] [name of copyright owner]
     
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/gnu-agpl-v3.0.rst
+++ b/gnu-agpl-v3.0.rst
@@ -639,21 +639,23 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-| <one line to give the program's name and a brief idea of what it does.>
-| Copyright (C) <year>  <name of author>
-|
-| This program is free software: you can redistribute it and/or modify
-| it under the terms of the GNU Affero General Public License as published by
-| the Free Software Foundation, either version 3 of the License, or
-| (at your option) any later version.
-|
-| This program is distributed in the hope that it will be useful,
-| but WITHOUT ANY WARRANTY; without even the implied warranty of
-| MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-| GNU Affero General Public License for more details.
-|
-| You should have received a copy of the GNU Affero General Public License
-| along with this program.  If not, see <http://www.gnu.org/licenses/>.
+::
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 

--- a/gnu-fdl-v1.3.rst
+++ b/gnu-fdl-v1.3.rst
@@ -437,21 +437,21 @@ ADDENDUM: How to use this License for your documents
 
 To use this License in a document you have written, include a copy of
 the License in the document and put the following copyright and
-license notices just after the title page:
+license notices just after the title page::
 
-|   Copyright (c)  <YEAR>  <YOUR NAME>.
-|   Permission is granted to copy, distribute and/or modify this document
-|   under the terms of the GNU Free Documentation License, Version 1.3
-|   or any later version published by the Free Software Foundation;
-|   with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.
-|   A copy of the license is included in the section entitled "GNU
-|   Free Documentation License".
+    Copyright (c)  <YEAR>  <YOUR NAME>.
+    Permission is granted to copy, distribute and/or modify this document
+    under the terms of the GNU Free Documentation License, Version 1.3
+    or any later version published by the Free Software Foundation;
+    with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.
+    A copy of the license is included in the section entitled "GNU
+    Free Documentation License".
 
 If you have Invariant Sections, Front-Cover Texts and Back-Cover Texts,
-replace the `with...Texts.` line with this:
+replace the `with...Texts.` line with this::
 
-|   with the Invariant Sections being <LIST THEIR TITLES>, with the
-|   Front-Cover Texts being <LIST>, and with the Back-Cover Texts being <LIST>.
+    with the Invariant Sections being <LIST THEIR TITLES>, with the
+    Front-Cover Texts being <LIST>, and with the Back-Cover Texts being <LIST>.
 
 If you have Invariant Sections without Cover Texts, or some other
 combination of the three, merge those two alternatives to suit the

--- a/gnu-gpl-v1.0.rst
+++ b/gnu-gpl-v1.0.rst
@@ -201,6 +201,8 @@ attach them to the start of each source file to most effectively convey
 the exclusion of warranty; and each file should have at least the
 "copyright" line and a pointer to where the full notice is found.
 
+::
+
     <one line to give the program's name and a brief idea of what it does.>
     Copyright (C) 19yy  <name of author>
 
@@ -222,7 +224,7 @@ the exclusion of warranty; and each file should have at least the
 Also add information on how to contact you by electronic and paper mail.
 
 If the program is interactive, make it output a short notice like this
-when it starts in an interactive mode:
+when it starts in an interactive mode::
 
     Gnomovision version 69, Copyright (C) 19xx name of author
     Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
@@ -236,7 +238,7 @@ they could even be mouse-clicks or menu items--whatever suits your program.
 
 You should also get your employer (if you work as a programmer) or your
 school, if any, to sign a "copyright disclaimer" for the program, if
-necessary.  Here a sample; alter the names:
+necessary.  Here a sample; alter the names::
 
     Yoyodyne, Inc., hereby disclaims all copyright interest in the
     program `Gnomovision' (a program to direct compilers to make passes

--- a/gnu-gpl-v2.0.rst
+++ b/gnu-gpl-v2.0.rst
@@ -291,6 +291,8 @@ to attach them to the start of each source file to most effectively
 convey the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
+::
+
     <one line to give the program's name and a brief idea of what it does.>
     Copyright (C) <year>  <name of author>
     
@@ -311,7 +313,7 @@ the "copyright" line and a pointer to where the full notice is found.
 Also add information on how to contact you by electronic and paper mail.
 
 If the program is interactive, make it output a short notice like this
-when it starts in an interactive mode:
+when it starts in an interactive mode::
 
     Gnomovision version 69, Copyright (C) year name of author
     Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
@@ -325,7 +327,7 @@ mouse-clicks or menu items--whatever suits your program.
 
 You should also get your employer (if you work as a programmer) or your
 school, if any, to sign a "copyright disclaimer" for the program, if
-necessary.  Here is a sample; alter the names:
+necessary.  Here is a sample; alter the names::
 
     Yoyodyne, Inc., hereby disclaims all copyright interest in the program
     `Gnomovision' (which makes passes at compilers) written by James Hacker.

--- a/gnu-gpl-v3.0.rst
+++ b/gnu-gpl-v3.0.rst
@@ -573,6 +573,8 @@ to the start of each source file to most effectively state the exclusion of warr
 and each file should have at least the "copyright" line and a pointer to
 where the full notice is found.
 
+::
+
     <one line to give the program's name and a brief idea of what it does.>
     Copyright (C) <year>  <name of author>
 
@@ -592,7 +594,7 @@ where the full notice is found.
 Also add information on how to contact you by electronic and paper mail.
 
 If the program does terminal interaction, make it output a short notice like this
-when it starts in an interactive mode:
+when it starts in an interactive mode::
 
     <program>  Copyright (C) <year>  <name of author>
     This program comes with ABSOLUTELY NO WARRANTY; for details type 'show w'.

--- a/gnu-lgpl-v2.1.rst
+++ b/gnu-lgpl-v2.1.rst
@@ -468,6 +468,8 @@ safest to attach them to the start of each source file to most effectively
 convey the exclusion of warranty; and each file should have at least the
 "copyright" line and a pointer to where the full notice is found.
 
+::
+
     <one line to give the library's name and a brief idea of what it does.>
     Copyright (C) <year>  <name of author>
 
@@ -489,7 +491,7 @@ Also add information on how to contact you by electronic and paper mail.
 
 You should also get your employer (if you work as a programmer) or your
 school, if any, to sign a "copyright disclaimer" for the library, if
-necessary.  Here is a sample; alter the names:
+necessary.  Here is a sample; alter the names::
 
     Yoyodyne, Inc., hereby disclaims all copyright interest in the
     library `Frob' (a library for tweaking knobs) written by James Random Hacker.

--- a/mpl-v2.0.rst
+++ b/mpl-v2.0.rst
@@ -393,9 +393,11 @@ notice described in Exhibit B of this License must be attached.
 Exhibit A - Source Code Form License Notice
 -------------------------------------------
 
-This Source Code Form is subject to the terms of the Mozilla Public
-License, v. 2.0. If a copy of the MPL was not distributed with this
-file, You can obtain one at http://mozilla.org/MPL/2.0/.
+::
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 If it is not possible or desirable to put the notice in a particular
 file, then You may include the notice in a location (such as a LICENSE


### PR DESCRIPTION
Several of the licenses include blocks of text for example license messages which were not rendering correctly (lines being joined together inappropriately, etc.). I converted them into rST literal blocks to fix this.